### PR TITLE
Visual Studio 2013 Fix

### DIFF
--- a/include/SWCP.h
+++ b/include/SWCP.h
@@ -6,6 +6,10 @@
 #include <sstream>
 #include <map>
 
+#ifdef VS2013
+	#include <stdint.h>
+#endif
+
 namespace SWCP 
 {
 	#if __cplusplus >= 201103L


### PR DESCRIPTION
Adds additional include required for compilation in Visual Studio 2013. Included only in this case, via preprocessor.